### PR TITLE
Use innerHTML from fragment

### DIFF
--- a/h-include.js
+++ b/h-include.js
@@ -58,15 +58,14 @@ var hinclude;
           }
         }
 
-        var nodeList = container.querySelectorAll(fragment);
+        var node = container.querySelector(fragment);
 
-        if (nodeList === 0) {
-          console.warning("Did not find fragment in response");
+        if (!node) {
+          console.warn("Did not find fragment in response");
           return;
         }
 
-        // Use the innerHTML of the first element matching the fragment selector
-        element.innerHTML = nodeList[0].innerHTML;
+        element.innerHTML = node.innerHTML;
         
         element.onSuccess && element.onSuccess();
       }

--- a/h-include.js
+++ b/h-include.js
@@ -42,7 +42,7 @@ var hinclude;
     classprefix: "include_",
 
     show_content: function (element, req) {
-      var i, include, message, fragment = element.getAttribute('fragment');
+      var i, include, message, fragment = element.getAttribute('fragment') || 'body';
       if (req.status === 200 || req.status === 304) {
         var container = document.implementation.createHTMLDocument().documentElement;
         container.innerHTML = req.responseText;
@@ -58,21 +58,15 @@ var hinclude;
           }
         }
 
-        if (fragment) {
-          var nodeList = container.querySelectorAll(fragment);
+        var nodeList = container.querySelectorAll(fragment);
 
-          if (nodeList === 0) {
-            console.warning("Did not find fragment in response");
-            return;
-          }
-
-          var wrap = document.createElement('div');
-          wrap.appendChild(nodeList[0].cloneNode(true));
-
-          element.innerHTML = wrap.innerHTML;
-        } else {
-          element.innerHTML = req.responseText;
+        if (nodeList === 0) {
+          console.warning("Did not find fragment in response");
+          return;
         }
+
+        // Use the innerHTML of the first element matching the fragment selector
+        element.innerHTML = nodeList[0].innerHTML;
         
         element.onSuccess && element.onSuccess();
       }

--- a/test/assets/visual-tests/domparser/body.html
+++ b/test/assets/visual-tests/domparser/body.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<p>This is a full HTML document which contains HTML, HEAD and BODY tags.</p>
+</body>
+</html>
+

--- a/test/assets/visual-tests/domparser/domparser.html
+++ b/test/assets/visual-tests/domparser/domparser.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="http://rawgit.com/WebReflection/document-register-element/master/build/document-register-element.js"></script>
+<!--
+<script src="http://rawgit.com/gustafnk/h-include/master/h-include.js"></script>
+-->
+<script src="../../h-include.js"></script>
+<style>
+h-include { 
+	display: block;
+	border: 2px solid orange; 
+}
+h-include[status=pass] {
+	border-color: green;
+}
+h-include[status=fail] {
+	border-color: red;
+}
+</style>
+</head>
+<body>
+<h1>DOMParser test</h1>
+<p>This is a visual test page for using a DOMParser for all included content (even partial HTML documents).</p>
+<p>Visual inspection isn't sufficient. 
+<ul>
+<li>
+Check in the DOM Inspector that all expected content is inserted and no unexpected content is (e.g. &lt;body&gt; or &lt;main&gt; elements).
+</li>
+<li>
+Check in the Console that no unexpected errors are thrown,
+and that appropriate warnings are logged.
+</li>
+</ul>
+
+<hr />
+
+<script>
+var hIncludes = document.getElementsByTagName('h-include');
+var hIncludeIndex = 0;
+</script>
+
+<h2>Partial HTML document</h2>
+<p>
+<small>This is the backwards-compatibility case.</small>
+<small>It should NOT insert a &lt;body&gt; element</small>
+</p>
+<p><h-include src="partial.html"></h-include></p>
+
+<script>
+hIncludes[hIncludeIndex].onSuccess = function() {
+	var className = this.querySelector('body') ? 'fail' : 'pass';
+	this.setAttribute('status', className);
+}
+hIncludeIndex++;
+</script>
+
+<hr />
+
+<h2>Full HTML document</h2>
+<p>
+<small>It should insert "document.body.innerHTML"</small>
+<small>It should NOT insert a &lt;body&gt; element</small>
+</p>
+<p><h-include src="body.html"></h-include></p>
+
+<script>
+hIncludes[hIncludeIndex].onSuccess = function() {
+	var className = this.querySelector('body') ? 'fail' : 'pass';
+	this.setAttribute('status', className);
+}
+hIncludeIndex++;
+</script>
+
+<hr />
+
+<h2>Full HTML document with fragment</h2>
+<p>
+<small>It should insert "document.querySelector('main').innerHTML"</small>
+<small>It should NOT insert a &lt;main&gt; element</small>
+</p>
+<p><h-include src="main.html" fragment="main"></h-include></p>
+
+<script>
+hIncludes[hIncludeIndex].onSuccess = function() {
+	var className = this.querySelector('main') ? 'fail' : 'pass';
+	this.setAttribute('status', className);
+}
+hIncludeIndex++;
+</script>
+
+<hr />
+
+<h2>Full HTML document with fragment that is not found</h2>
+<p>
+<small>It should NOT insert ANYTHING because it fails to find the fragment</small>
+</p>
+<p><h-include src="body.html" fragment="main"></h-include></p>
+
+<script>
+hIncludes[hIncludeIndex].onSuccess = function() {
+	var className = 'fail';
+	this.setAttribute('status', className);
+}
+hIncludes[hIncludeIndex].setAttribute('status', 'pass');
+hIncludeIndex++;
+</script>
+
+</body>
+</html>
+

--- a/test/assets/visual-tests/domparser/main.html
+++ b/test/assets/visual-tests/domparser/main.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This is a full HTML document which also contains a MAIN tag.</p>
+<main>
+<p>This is the &lt;main&gt; content</p>
+</main>
+</body>
+</html>
+

--- a/test/assets/visual-tests/domparser/partial.html
+++ b/test/assets/visual-tests/domparser/partial.html
@@ -1,0 +1,2 @@
+<p>This is a partial HTML document. It has no HTML, HEAD or BODY tags</p>
+


### PR DESCRIPTION
Also, refactor so that 'body' is default fragment. This is ok, since the HTML parser will create a body for documents without one.

@shogun70 what do you think?
