### PR TITLE
Add navigational feature

### DIFF
--- a/h-include.js
+++ b/h-include.js
@@ -50,6 +50,12 @@ window.HIncludeElement = (function() {
 
       var node = element.extractFragment.call(element, container, fragment, req);
       element.replaceContent.call(element, node);
+
+      // Register navigation
+      var navigationAttribute = element.getAttribute('navigate');
+      if (navigationAttribute === '' || navigationAttribute === 'true') {
+        registerNavigation(element);
+      }
     }
 
     element.onEnd.call(element, req);
@@ -126,6 +132,57 @@ window.HIncludeElement = (function() {
       outstanding -= 1;
     }
   };
+
+  var getElement = function(elementArg, nodeName) {
+    var element;
+    element = elementArg;
+    while (element.parentNode && element.nodeName !== nodeName) {
+      element = element.parentNode;
+    }
+
+    if (element.nodeName === nodeName) {
+      return element;
+    }
+  }
+
+  var getLink = function(element) {
+    var link = getElement(element, 'A');
+
+    if (link && link.href.length !== 0) {
+      return link;
+    }
+  };
+
+  var getHinclude = function(element) {
+    return getElement(element, 'H-INCLUDE');
+  };
+
+  var handle = function(e) {
+    var link = getLink(e.target);
+
+    if (!link) return;
+
+    // Detect target attribute
+    var targetAttribute = link.getAttribute('target');
+    if (targetAttribute === '_top') {
+      // Treat as regular link
+      return;
+    }
+
+    // Navigate
+    var href = link.href;
+    if (!href) return;
+
+    var hElement = getHinclude(e.target);
+    hElement.setAttribute('src', href);
+
+    e.preventDefault();
+  };
+
+  var registerNavigation = function(element) {
+    element.addEventListener('click', handle, true);
+  };
+
 
   var proto = Object.create(HTMLElement.prototype);
 

--- a/test/assets/navigation/1.html
+++ b/test/assets/navigation/1.html
@@ -1,0 +1,1 @@
+<div><a href="2.html"><i>Click</i> here <b>now</b></a></div>

--- a/test/assets/navigation/2.html
+++ b/test/assets/navigation/2.html
@@ -1,0 +1,11 @@
+<div>
+<a href="1.html">Back</a>
+<br><br>
+A box
+<br>
+With several lines
+<br>
+With <a href="3.html">another link</a>
+<br>
+And <a href="https://github.com/gustafnk/h-include" target="_top">an external link</a>
+</div>

--- a/test/assets/navigation/3.html
+++ b/test/assets/navigation/3.html
@@ -1,0 +1,5 @@
+<div>
+<a href="2.html">Back</a>
+<br><br>
+This is the last box. Goodbye.
+</div>

--- a/test/assets/navigation/index.html
+++ b/test/assets/navigation/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <title>h-include Tests</title>
+  <link type="text/css" rel="stylesheet" href="../style.css">
+  <script type="text/javascript" src="../document-register-element.js"></script>
+  <script type="text/javascript" src="../h-include.js"></script>
+  <style type="text/css">
+  .error_text { display: none; }
+  .include_404 .error_404 { display: inline; text-decoration: underline; }
+  .box { border-style: dashed; border-color: black; width: 200px; padding: 50px;}
+  </style>
+</head>
+<body>
+
+<h1>h-include.js navigation test page</h1>
+
+<h2 id="h">Fragment</h2>
+
+<p class="box" id="box-1"><h-include src="1.html" navigate></h-include></p>
+<p class="box" id="box-2"><h-include src="1.html" navigate></h-include></p>
+<p class="box" id="box-3"><h-include src="1.html" navigate></h-include></p>
+
+</body>
+</html>


### PR DESCRIPTION
Enables light-weight navigation within an h-include
Adding the attribute `navigate` or `navigate=true` enables this feature
Link clicks within the h-include is tracked and the `src` attribute for
  the given h-include is modified, which reloads the fragment with its
  new src url.
Add `target="_top"` for external links, similar to iFrames