### PR TITLE
README: Mention which API is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ document.registerElement('h-include-improved', {
 
 ## Lazy loading example
 
+This example uses the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) in a `load` event handler on `window`, to lazy-load `<h-include-lazy>` element content.
+
 ```js
 window.addEventListener('load', function() {
   var elements = document.getElementsByTagName('h-include-lazy');


### PR DESCRIPTION
This PR adds a line to the documentation in the README, to:

  - mention Intersection Observers API with a link
  - note the custom element
  - couch the example in familiar Web development language