### PR TITLE
Link to h-include / intersection observer example repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Example:
 <h-include-lazy src="lazy-loaded-fragment.html"></h-include-lazy>
 ```
 
+Example repo using plain h-include (without lazy) and the Intersection Observer API to pull in content on ‘in-view’ scroll interaction can be found [here](https://github.com/nicolasdelfino/iobserver-h-include).
+
 ### h-import
 
 Request an HTML resource and include all found script and stylesheet references.


### PR DESCRIPTION
Add a link to example node repo using 'vanilla' h-include (without the lazy extension) along with the Intersection Observer API.