### PR TITLE
Headers handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,69 @@ The alt attribute functions as an alternative source of inclusion should the url
 <h-include src="unavailable.html" alt="alternative.html"></h-include>
 ```
 
+### HTTP Headers
+
+Set custom request headers and subscribe to response headers by using the HIncludeConfig configuration, example:
+
+```js
+HIncludeConfig = {
+  setRequestHeaders: [{key, value}],
+  getResponseHeaderKeys: ['key'],
+  onGetResponseHeaders: function (responseHeaders) {
+    // responseHeaders: [{key, value}]
+  },
+  renderStatusCodes: [Number]
+};
+```
+
+#### HIncludeConfig.setRequestHeaders
+
+Array of headers you want to set, e.g:
+
+```js
+HIncludeConfig = {
+  setRequestHeaders: [{key: 'Cache-Control', value: 'max-age=10000, public'}]
+};
+```
+
+#### HIncludeConfig.getResponseHeaderKeys and onGetResponseHeaders callback
+
+You subscribe to reponse headers by providing an array of headers and a callback function (required).
+
+##### getResponseHeaderKeys
+Array of headers you want to listen to,  e.g:
+
+```js
+HIncludeConfig = {
+  getResponseHeaderKeys: ['Cache-Control', 'Content-Type']
+};
+```
+
+##### onGetResponseHeaders (required when using getResponseHeaderKeys)
+Returns an array of headers matching the header keys provided by getResponseHeaderKeys if available in response, e.g:
+
+```js
+HIncludeConfig = {
+  getResponseHeaderKeys: ['Cache-Control', 'Content-Type'],
+  onGetResponseHeaders: function (responseHeaders) {
+    // responseHeaders: [{key, value}]
+  },
+};
+```
+
+#### renderStatusCodes
+Array of status codes where h-include is allowed to render or refresh the element (defaults to 200 / 304 codes). 
+
+Providing `renderStatusCodes` will also partially override the behaviour where the status code of the request gets appended to the element class list given it falls under the 400 range.
+
+Client / server errors will still be provided (see Error Handling).
+
+```js
+HIncludeConfig = {
+  acceptedStatusCodes: [Number]
+};
+```
+
 ### Refresh method
 
 Refresh an element by using the `refresh()` method:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example usage, in summary:
 | ESI | ESI + h‑include‑lazy | Pages with *homogeneous* lists, lazy loaded on scroll below the fold |
 | ESI + h‑import‑lazy | ESI + h‑include‑lazy | Pages with *heterogeneous* content, lazy loaded on scroll below the fold together with resource fragments |
 | h‑import | h‑include (etc) | Sites without access to ESI |
-
+                                                                                                                                                   
 ### h-include-lazy
 
 Only includes the HTML resource if the element is about to enter the viewport, by default 400 pixels margin, using the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) (which needs to be polyfilled).
@@ -222,8 +222,7 @@ HIncludeConfig = {
   getResponseHeaderKeys: ['key'],
   onGetResponseHeaders: function (responseHeaders) {
     // responseHeaders: [{key, value}]
-  },
-  renderStatusCodes: [Number]
+  }
 };
 ```
 
@@ -259,19 +258,6 @@ HIncludeConfig = {
   onGetResponseHeaders: function (responseHeaders) {
     // responseHeaders: [{key, value}]
   },
-};
-```
-
-#### renderStatusCodes
-Array of status codes where h-include is allowed to render or refresh the element (defaults to 200 / 304 codes). 
-
-Providing `renderStatusCodes` will also partially override the behaviour where the status code of the request gets appended to the element class list given it falls under the 400 range.
-
-Client / server errors will still be provided (see Error Handling).
-
-```js
-HIncludeConfig = {
-  acceptedStatusCodes: [Number]
 };
 ```
 
@@ -336,6 +322,8 @@ If `checkRecursion` is `true`, h-include will traverse the DOM upwards to find a
 ## Error Handling
 
 If fetching the included URL results in a 404 Not Found status code, the class of the include element will be changed to include_404. Likewise, a 500 Server Error status code will result in the include element’s class being changed to include_500.
+
+Status 304 - Not Modified will not be reflected in the element class.
 
 ## Browser support
 

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -191,7 +191,7 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
             }
             var responseHeaders = config.getResponseHeaderKeys.map(function(headerKey) {
               return {key: headerKey, value: req.getResponseHeader(headerKey)};
-            })
+            });
             config.onGetResponseHeaders(responseHeaders);
           }
           includeCallback(element, req);

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -56,18 +56,10 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
     return false;
   }
 
-  function shouldProvideInclusionStatus(req, shouldRender) {
-    if(req.status < 400 && config && config.renderStatusCodes && !shouldRender) {
-      return false;
-    } 
-    return true;
-  }
-
   function showContent(element, req){
     var fragment = element.getAttribute('fragment') || 'body';
-    var shouldRender = isValidRenderStatus(req.status);
 
-    if(shouldRender) {
+    if(req.status === 200) {
       var container = element.createContainer.call(element, req);
 
       if (config && config.checkRecursion) {
@@ -76,10 +68,8 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
 
       var node = element.extractFragment.call(element, container, fragment, req);
       element.replaceContent.call(element, node);
-    } else {
-      // accepted request status failed
-    }
-    element.onEnd.call(element, req, shouldRender);
+    } 
+    element.onEnd.call(element, req);
   }
 
   function setContentAsync(element, req) {
@@ -277,8 +267,8 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
     this.innerHTML = node.innerHTML;
   };
 
-  proto.onEnd = function(req, shouldRender) {
-    if(shouldProvideInclusionStatus(req, shouldRender)) {
+  proto.onEnd = function(req) {
+    if(req.status !== 304) {
       var tokens = this.className.split(/\s+/);
       var otherClasses = tokens.filter(function(token){
         return !token.match(/^include_\d+$/i) && !token.match(/^included/i);

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -192,10 +192,9 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
       req.open('GET', url, true);
 
       if (config && config.setRequestHeaders) {
-        for (var i = 0; i < config.setRequestHeaders.length; i++) {
-          var header = config.setRequestHeaders[i];
+        config.setRequestHeaders.forEach(function(header) {
           req.setRequestHeader(header.key, header.value);
-        }
+        }) 
       }
 
       req.send('');

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -44,9 +44,30 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   var outstanding = 0;
   var altSrcInclude = false;
 
+  function isValidRenderStatus(status) {
+    var renderStatusCodes = [200, 304];
+
+    if(config && config.renderStatusCodes) {
+      renderStatusCodes = config.renderStatusCodes;
+    }
+    if(renderStatusCodes.indexOf(status) > -1) {
+      return true;
+    }
+    return false;
+  }
+
+  function shouldProvideInclusionStatus(req, shouldRender) {
+    if(req.status < 400 && config && config.renderStatusCodes && !shouldRender) {
+      return false;
+    } 
+    return true;
+  }
+
   function showContent(element, req){
     var fragment = element.getAttribute('fragment') || 'body';
-    if (req.status === 200 || req.status === 304) {
+    var shouldRender = isValidRenderStatus(req.status);
+
+    if(shouldRender) {
       var container = element.createContainer.call(element, req);
 
       if (config && config.checkRecursion) {
@@ -55,8 +76,10 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
 
       var node = element.extractFragment.call(element, container, fragment, req);
       element.replaceContent.call(element, node);
+    } else {
+      // accepted request status failed
     }
-    element.onEnd.call(element, req);
+    element.onEnd.call(element, req, shouldRender);
   }
 
   function setContentAsync(element, req) {
@@ -162,12 +185,29 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
           outstanding -= 1;
           include(element, includeCallback);
         } else {
+          if (config && config.getResponseHeaderKeys) {
+            if(!config.onGetResponseHeaders) {
+              throw new Error('onGetResponseHeaders function not provided in config');
+            }
+            var responseHeaders = config.getResponseHeaderKeys.map(function(headerKey) {
+              return {key: headerKey, value: req.getResponseHeader(headerKey)};
+            })
+            config.onGetResponseHeaders(responseHeaders);
+          }
           includeCallback(element, req);
         }
       }
     };
     try {
       req.open('GET', url, true);
+
+      if (config && config.setRequestHeaders) {
+        for (var i = 0; i < config.setRequestHeaders.length; i++) {
+          var header = config.setRequestHeaders[i];
+          req.setRequestHeader(header.key, header.value);
+        }
+      }
+
       req.send('');
     } catch (e) {
       outstanding -= 1;
@@ -237,14 +277,16 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
     this.innerHTML = node.innerHTML;
   };
 
-  proto.onEnd = function(req) {
-    var tokens = this.className.split(/\s+/);
-    var otherClasses = tokens.filter(function(token){
-      return !token.match(/^include_\d+$/i) && !token.match(/^included/i);
-    }).join(' ');
-
-    this.className = otherClasses + (otherClasses ? ' ' : '') +
-      'included ' + classprefix + req.status;
+  proto.onEnd = function(req, shouldRender) {
+    if(shouldProvideInclusionStatus(req, shouldRender)) {
+      var tokens = this.className.split(/\s+/);
+      var otherClasses = tokens.filter(function(token){
+        return !token.match(/^include_\d+$/i) && !token.match(/^included/i);
+      }).join(' ');
+  
+      this.className = otherClasses + (otherClasses ? ' ' : '') +
+        'included ' + classprefix + req.status;
+    }
 
     altSrcInclude = false;
   };


### PR DESCRIPTION
# HTTP Headers

This pr introduces a way of managing headers using the window.HIncludeConfig.

Besides being able to manage headers, this pr introduces two additional changes for requests:
* The element is now only updated if the request results in a status code 200. 
* Status 304 - Not Modified will not be added to the element css class list.

I have provided three configuration keys and one hook:

```js
HIncludeConfig = {
  setRequestHeaders: [{key, value}],
  getResponseHeaderKeys: ['key'],
  onGetResponseHeaders: function (responseHeaders) {
    // responseHeaders: [{key, value}]
  }
};
```

Detailed information in README but gist:

### setRequestHeaders: 
Array of headers you to set
### getResponseHeaderKeys: 
Array of headers to listen to
### onGetResponseHeaders: 
Returns an array of headers matching the header keys provided by getResponseHeaderKeys if available in response

## WIP:
* Tests 
* Node demo

For now I created a demo repo showcasing the headers functionality in this pr and its possible usage with ETags.

https://github.com/nicolasdelfino/express-etags-304/tree/h-include