### PR TITLE
Simplify web tests

### DIFF
--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -32,7 +32,7 @@ Install [Sauce Connect Proxy](https://wiki.saucelabs.com/display/DOCS/Sauce+Conn
 
   > bin/sc -u [sauce username] -k [sauce access ke] -i tunnel1
 
-Open a new tab...
+Open a new terminal tab...
 
   > SAUCE_TUNNEL_ID=tunnel1 SAUCE_USERNAME=[sauce username] SAUCE_ACCESS_KEY=[sauce access key] npm run remote-tests
 
@@ -40,8 +40,15 @@ Open a new tab...
 CI Testing
 ----------
 
-Travis CI will automatically run the tests when commits are pushed to Github
-(assuming the account is registered with Travis and the repository is registered with Sauce Labs).
+TODO: Github Actions integration (work started).
+
+Today, tests need to be run at a local dev machine.
 
 Testing is done in the browser / OS environments defined in "__tests__/browsers.json".
+
+
+Manual Testing in IE11
+--------------
+
+IE11 is hard to reliably automate through Selenium. Therefore, use the links in the `static/index.html` page and (for each link) wait for the alerts to be shown.
 

--- a/__tests__/browser-test.js
+++ b/__tests__/browser-test.js
@@ -15,6 +15,7 @@ const caps = {};
 let browsers;
 
 const timeout = 6000;
+const smallTimeout = 1000;
 const log = true;
 
 if (process.env.IS_LOCAL === 'true') {
@@ -43,6 +44,7 @@ if (process.env.IS_LOCAL === 'true') {
     build: buildId,
     username: username,
     accessKey: accessKey,
+    screenResolution: "1600x1200"
   });
 }
 
@@ -177,6 +179,7 @@ browsers.forEach(browser => {
       expect(cText).toBe('This is the last box. Goodbye.');
     });
 
+    // When
     it('does perform inclusion of src when predicate function succeeds', async () => {
       await driver.get('http://localhost:8080/static/when/when-pass-use-src.html');
 
@@ -189,7 +192,7 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/when/when-fail.html');
 
       try {
-        await driver.findElement(By.id('when-included'))
+        await driver.findElement(By.id('when-included'), smallTimeout)
       } catch (error) {
         expect(error.name).toBe('NoSuchElementError');
       }
@@ -199,7 +202,7 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/when/when-fail.html');
 
       try {
-        await driver.findElement(By.id('when-false-src-included'))
+        await driver.findElement(By.id('when-false-src-included'), smallTimeout)
       } catch (error) {
         expect(error.name).toBe('NoSuchElementError');
       }
@@ -209,7 +212,7 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/when/when-fail-if-when-false-src.html');
 
       try {
-        await driver.findElement(By.id('when-included'))
+        await driver.findElement(By.id('when-included'), smallTimeout)
       } catch (error) {
         expect(error.name).toBe('NoSuchElementError');
 
@@ -219,13 +222,14 @@ browsers.forEach(browser => {
       }
     });
 
+    // Alt
     it('uses alt attribute when forcing a 404', async () => {
       await driver.get('http://localhost:8080/static/alt/alt.html');
 
       try {
-        await driver.findElement(By.id('default-included'))
+        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
 
         const cSelector = By.id('alt-included');
         await driver.wait(until.elementLocated(cSelector), timeout);
@@ -241,9 +245,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/no-alt.html');
 
       try {
-        await driver.findElement(By.id('alt-included'))
+        await driver.wait(until.elementLocated(By.id('alt-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
       }
     });
 
@@ -251,9 +255,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-fail-no-when-false-src-alt-error.html');
 
       try {
-        await driver.findElement(By.id('alt-included'))
+        await driver.wait(until.elementLocated(By.id('alt-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
       }
     });
 
@@ -261,9 +265,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-fail-no-when-false-src-alt-pass.html');
 
       try {
-        await driver.findElement(By.id('default-included'))
+        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
 
         const cSelector = By.id('alt-included');
         await driver.wait(until.elementLocated(cSelector), timeout);
@@ -279,9 +283,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-fail-when-false-src-fail-alt-error.html');
 
       try {
-        await driver.findElement(By.id('alt-included'))
+        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
       }
     });
 
@@ -289,9 +293,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-fail-when-false-src-fail-alt-pass.html');
 
       try {
-        await driver.findElement(By.id('default-included'))
+        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
 
         const cSelector = By.id('alt-included');
         await driver.wait(until.elementLocated(cSelector), timeout);
@@ -307,9 +311,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-pass-no-when-false-src-alt-error.html');
 
       try {
-        await driver.findElement(By.id('alt-included'))
+        await driver.wait(until.elementLocated(By.id('alt-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
       }
     });
 
@@ -317,9 +321,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-pass-no-when-false-src-alt-pass.html');
 
       try {
-        await driver.findElement(By.id('default-included'))
+        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
 
         const cSelector = By.id('alt-included');
         await driver.wait(until.elementLocated(cSelector), timeout);
@@ -335,9 +339,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-pass-when-false-src-fail-alt-error.html');
 
       try {
-        await driver.findElement(By.id('alt-included'))
+        await driver.wait(until.elementLocated(By.id('alt-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
       }
     });
 
@@ -345,9 +349,9 @@ browsers.forEach(browser => {
       await driver.get('http://localhost:8080/static/alt/when-pass-when-false-src-fail-alt-pass.html');
 
       try {
-        await driver.findElement(By.id('default-included'))
+        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
       } catch (error) {
-        expect(error.name).toBe('NoSuchElementError');
+        expect(error.name).toBe('TimeoutError');
 
         const cSelector = By.id('alt-included');
         await driver.wait(until.elementLocated(cSelector), timeout);
@@ -359,11 +363,12 @@ browsers.forEach(browser => {
       }
     });
 
-    if (browser.browserName !== 'MicrosoftEdge' && browser.platform !== 'Windows 10') {
+    // Media
+    if (browser.browserName !== 'safari' && browser.version !== '10') {
       it('loads small fragment for small viewport', async () => {
         const viewport = driver.manage().window();
-        await viewport.setSize(480, 800); // width, height
-                await driver.get('http://localhost:8080/static/media/');
+        await viewport.setSize(1024, 768); // width, height
+        await driver.get('http://localhost:8080/static/media/');
 
         const a = await driver.findElement(By.id('a')).getText();
 

--- a/__tests__/browsers-remote.json
+++ b/__tests__/browsers-remote.json
@@ -1,16 +1,6 @@
 [
 {"browserName":"chrome","platform":"Windows 10","version":"latest"},
-{"browserName":"chrome","platform":"Windows 10","version":"50"},
-{"browserName":"chrome","platform":"Windows 10","version":"65"},
-{"browserName":"chrome","platform":"Windows 10","version":"68"},
 {"browserName":"firefox","platform":"OS X 10.11","version":"latest"},
-{"browserName":"firefox","platform":"OS X 10.11","version":"55"},
-{"browserName":"firefox","platform":"OS X 10.11","version":"64"},
 {"browserName":"MicrosoftEdge","platform":"Windows 10","version":"latest"},
-{"browserName":"internet explorer","platform":"Windows 10","version":"11"},
-{"browserName":"internet explorer","platform":"Windows 7","version":"11"},
-{"browserName":"safari","platform":"macOS 10.13","version":"11.1"},
-{"browserName":"safari","platform":"OS X 10.12","version":"11"},
-{"browserName":"safari","platform":"OS X 10.11","version":"10"},
-{"browserName":"safari","platform":"OS X 10.11","version":"9"}
+{"browserName":"safari","platform":"macOS 10.15","version":"latest"}
 ]

--- a/__tests__/browsers-remote.json
+++ b/__tests__/browsers-remote.json
@@ -2,5 +2,13 @@
 {"browserName":"chrome","platform":"Windows 10","version":"latest"},
 {"browserName":"firefox","platform":"OS X 10.11","version":"latest"},
 {"browserName":"MicrosoftEdge","platform":"Windows 10","version":"latest"},
-{"browserName":"safari","platform":"macOS 10.15","version":"latest"}
+{"browserName":"safari","platform":"macOS 10.15","version":"latest"},
+
+{"browserName":"chrome","platform":"Windows 10","version":"latest - 4"},
+{"browserName":"firefox","platform":"OS X 10.11","version":"latest - 4"},
+{"browserName":"MicrosoftEdge","platform":"Windows 10","version":"latest - 4"},
+{"browserName":"safari","platform":"macOS 10.15","version":"latest - 4"},
+
+{"browserName":"microsoftedge","platform":"Windows 10","version":"13"},
+{"browserName":"safari","platform":"macOS 10.12","version":"10"}
 ]

--- a/static/alt/alt.html
+++ b/static/alt/alt.html
@@ -20,5 +20,16 @@
     <h2 id="h">Request error - Alt</h2>
 
     <h-include src="nothing" alt="fragment3.html"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'alt - this text is included');
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/no-alt.html
+++ b/static/alt/no-alt.html
@@ -20,5 +20,15 @@
     <h2 id="h">Request error - Alt</h2>
 
     <h-include src="nothing"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+
+  expect(!a);
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-fail-no-when-false-src-alt-pass.html
+++ b/static/alt/when-fail-no-when-false-src-alt-pass.html
@@ -30,5 +30,16 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" alt="fragment3.html"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'alt - this text is included');
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-fail-when-false-src-fail-alt-error.html
+++ b/static/alt/when-fail-when-false-src-fail-alt-error.html
@@ -30,5 +30,15 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" when-false-src="nothing2" alt="nothing3"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+
+  expect(!a);
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-fail-when-false-src-fail-alt-pass.html
+++ b/static/alt/when-fail-when-false-src-fail-alt-pass.html
@@ -30,5 +30,16 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" when-false-src="nothing2" alt="fragment3.html"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'alt - this text is included');
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-pass-no-when-false-src-alt-error.html
+++ b/static/alt/when-pass-no-when-false-src-alt-error.html
@@ -30,5 +30,15 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" alt="nothing"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+
+  expect(!a);
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-pass-no-when-false-src-alt-pass.html
+++ b/static/alt/when-pass-no-when-false-src-alt-pass.html
@@ -30,5 +30,16 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" alt="fragment3.html"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'alt - this text is included');
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-pass-when-false-src-fail-alt-error.html
+++ b/static/alt/when-pass-when-false-src-fail-alt-error.html
@@ -30,5 +30,15 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" when-false-src="nothing2" alt="nothing3"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+
+  expect(!a);
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/alt/when-pass-when-false-src-fail-alt-pass.html
+++ b/static/alt/when-pass-when-false-src-fail-alt-pass.html
@@ -30,5 +30,16 @@
 
     <h-include
       src="nothing" when="org.project.predicateFunction" when-false-src="nothing2" alt="fragment3.html"></h-include>
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('alt-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'alt - this text is included');
+}, 1000);
+</script>
   </body>
 </html>

--- a/static/basic-async/index.html
+++ b/static/basic-async/index.html
@@ -30,5 +30,20 @@
 
 <p id="c"><h-include src="nothing"><span class="error_text error_404">this content is shown because there was a 404</span><span class="error_text error_500">this content is shown because there was a 500</span></h-include>.</p>
 
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('included-1');
+  const b = document.getElementById('included-2');
+
+  const aText = a.innerHTML;
+  const bText = b.innerHTML;
+
+  expect(aText === 'this text is included');
+  expect(bText === 'this text overwrote what was just there');
+}, 1000);
+</script>
+
 </body>
 </html>

--- a/static/basic/index.html
+++ b/static/basic/index.html
@@ -30,5 +30,20 @@
 
 <p id="c"><h-include src="nothing"><span class="error_text error_404">this content is shown because there was a 404</span><span class="error_text error_500">this content is shown because there was a 500</span></h-include>.</p>
 
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('included-1');
+  const b = document.getElementById('included-2');
+
+  const aText = a.innerHTML;
+  const bText = b.innerHTML;
+
+  expect(aText === 'this text is included');
+  expect(bText === 'this text overwrote what was just there');
+}, 1000);
+</script>
+
 </body>
 </html>

--- a/static/expect.js
+++ b/static/expect.js
@@ -1,0 +1,6 @@
+var i = 0;
+window.expect = function(passed, actual){
+  console.log('Test', i, 'passed?', passed, !passed ? actual : '');
+  // alert('Test ' + i + ' passed? ' + passed + ' ' + (!passed ? actual : ''));
+  i++;  
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,23 @@
+<h1>Links for visual tests</h1>
+
+<ul>
+  <li><a href="basic/index.html">basic</a></li>
+  <li><a href="basic-async/index.html">basic async</a></li>
+  <li><a href="lazy-extension/index.html">lazy extension</a></li>
+  <li><a href="none/index.html">none</a></li>
+  <li><a href="when/when-pass-use-src.html">when 1</a></li>
+  <li><a href="when/when-fail.html">when 2 (fails)</a></li>
+  <li><a href="when/when-fail-if-when-false-src.html">when 3</a></li>
+  <li><a href="when/when-fail-if-when-false-src.html">when 4</a></li>
+  <li><a href="when/when-fail-if-when-false-src.html">when 5</a></li>
+  <li><a href="alt/alt.html">alt 1</a></li>
+  <li><a href="alt/no-alt.html">alt 2</a></li>
+  <li><a href="alt/when-fail-no-when-false-src-alt-pass.html">alt 3</a></li>
+  <li><a href="alt/when-fail-when-false-src-fail-alt-error.html">alt 4</a></li>
+  <li><a href="alt/when-fail-when-false-src-fail-alt-pass.html">alt 5</a></li>
+  <li><a href="alt/when-pass-no-when-false-src-alt-error.html">alt 6</a></li>
+  <li><a href="alt/when-pass-no-when-false-src-alt-pass.html">alt 7</a></li>
+  <li><a href="alt/when-pass-when-false-src-fail-alt-error.html">alt 8</a></li>
+  <li><a href="alt/when-pass-when-false-src-fail-alt-pass.html">alt 9</a></li>
+</ul>
+

--- a/static/lazy-extension/index.html
+++ b/static/lazy-extension/index.html
@@ -87,5 +87,16 @@ Soon an explosion of includes....
 
 Fin.
 
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('included-3');
+  const aText = a.innerHTML;
+
+  expect(aText === 'this text is included 3');
+}, 1000);
+</script>
+
 </body>
 </html>

--- a/static/media/index.html
+++ b/static/media/index.html
@@ -17,8 +17,18 @@
 
 <h2 id="h">Media Include</h2>
 
-<p id="a" name="a"><h-include media="screen and (max-width: 600px)" src="small.html"></h-include><h-include media="screen and (min-width: 601px)" src="large.html"></h-include></p>
+<p id="a" name="a"><h-include media="screen and (max-width: 1124px)" src="small.html"></h-include><h-include media="screen and (min-width: 1125px)" src="large.html"></h-include></p>
 
 
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('a');
+  const aText = a.textContent.trim();
+
+  expect(aText === 'Small viewport', aText);
+}, 1000);
+</script>
 </body>
 </html>

--- a/static/none/index.html
+++ b/static/none/index.html
@@ -19,5 +19,16 @@
 
 <p id="a" name="a">1st para</p>
 
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('a');
+  const aText = a.innerHTML;
+
+  expect(aText === '1st para');
+}, 1000);
+</script>
 </body>
 </html>

--- a/static/when/when-fail-if-when-false-src.html
+++ b/static/when/when-fail-if-when-false-src.html
@@ -29,6 +29,16 @@
 
   <h-include src="fragment.html" when="org.project.predicateFunction" when-false-src="fragment2.html"></h-include>
 
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('when-false-src-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'when-false-src - this text is included');
+}, 1000);
+</script>
 </body>
 
 </html>

--- a/static/when/when-fail.html
+++ b/static/when/when-fail.html
@@ -29,6 +29,16 @@
 
   <h-include src="fragment.html" when="org.project.predicateFunction"></h-include>
 
+<!-- Legacy browser tests -->
+<!-- Seems to reveal a bug... -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('when-included');
+
+  expect(!a);
+}, 1000);
+</script>
 </body>
 
 </html>

--- a/static/when/when-pass-use-src.html
+++ b/static/when/when-pass-use-src.html
@@ -29,6 +29,18 @@
 
   <h-include src="fragment.html" when="org.project.predicateFunction" when-false-src="fragment2.html"></h-include>
 
+
+
+<!-- Legacy browser tests -->
+<script src="../expect.js"></script>
+<script type="text/javascript">
+setTimeout(function(){
+  const a = document.getElementById('when-included');
+  const aText = a.innerHTML;
+
+  expect(aText === 'when - this text is included');
+}, 1000);
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
- Write in-browser manual tests for IE11
- Element existence checks were not correct, fixed
- Fix media test
- Better browser list for testing: latest evergreens, latest evergreens 4 versions back, browsers before CEv1