### PR TITLE
add abililty to pass root property to IntersectionObserver

### DIFF
--- a/lib/h-include-extensions.js
+++ b/lib/h-include-extensions.js
@@ -152,6 +152,7 @@ window.HInclude.initLazyLoad = function(selectorArg, configArg){
   }
 
   var config = {
+    root: configArg && configArg.root || null,
     rootMargin: configArg && configArg.rootMargin || '400px 0px',
     threshold: configArg && configArg.threshold || 0.01 // 1% of the target is visible
   };


### PR DESCRIPTION
In order to get IntersectionObserver to work in iframes on Chromium, it is required to pass the `root` property in the options for IntersectionObserver. This change just adds this ability.