### PR TITLE
Fix h-include issue 112

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-                  tunnelIdentifier: github-action-tunnel
+                  tunnelName: github-action-tunnel
                   region: us-west-1
             # ...
             - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
                   tunnelIdentifier: github-action-tunnel
+                  region: us-west-1
             # ...
             - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
             - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: saucelabs/sauce-connect-action@v3
+            - uses: saucelabs/sauce-connect-action@v3.0.0
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,11 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: saucelabs/sauce-connect-action@v2.0.0
+            - uses: saucelabs/sauce-connect-action@v3
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
                   tunnelIdentifier: github-action-tunnel
-                  scVersion: 4.6.4
             # ...
             - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
             - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/__tests__/browser-test.js
+++ b/__tests__/browser-test.js
@@ -276,21 +276,13 @@ browsers.forEach(browser => {
       }
     });
 
-    it('does perform inclusion when predicate fails, no when-false-src and using a valid alt src', async () => {
+    it('does not perform inclusion when predicate fails, no when-false-src and using a valid alt src', async () => {
       await driver.get('http://tabby-prickly-rule.glitch.me/static/alt/when-fail-no-when-false-src-alt-pass.html');
 
       try {
-        await driver.wait(until.elementLocated(By.id('default-included')), smallTimeout);
+        await driver.wait(until.elementLocated(By.id('alt-included')), smallTimeout);
       } catch (error) {
         expect(error.name).toBe('TimeoutError');
-
-        const cSelector = By.id('alt-included');
-        await driver.wait(until.elementLocated(cSelector), timeout);
-
-        const c = await driver.findElement(cSelector);
-        const cText = await c.getText();
-
-        expect(cText).toBe('alt - this text is included');
       }
     });
 

--- a/__tests__/browsers-remote.json
+++ b/__tests__/browsers-remote.json
@@ -1,11 +1,6 @@
 [
-{"browserName":"chrome","platform":"Windows 10","version":"latest"},
-{"browserName":"firefox","platform":"OS X 10.11","version":"latest"},
-{"browserName":"safari","platform":"macOS 10.15","version":"latest"},
-
-{"browserName":"chrome","platform":"Windows 10","version":"latest - 4"},
-{"browserName":"firefox","platform":"OS X 10.11","version":"latest - 4"},
-{"browserName":"safari","platform":"macOS 10.15","version":"latest - 4"},
-
-{"browserName":"safari","platform":"macOS 10.12","version":"10"}
+{"browserName":"chrome","platform":"Windows 11","version":"latest"},
+{"browserName":"firefox","platform":"Windows 11","version":"latest"},
+{"browserName":"safari","platform":"macOS 13","version":"latest"},
+{"browserName":"MicrosoftEdge","platform":"Windows 11","version":"latest"}
 ]

--- a/h-include.js
+++ b/h-include.js
@@ -108,7 +108,7 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   var getUrl = function(element) {
     var whenAttribute = element.getAttribute('when');
     var whenFalseUrl = element.getAttribute('when-false-src');
-    var whenCondition = whenAttribute && whenFalseUrl && !element.conditionalInclusion.call(element, 'when');
+    var whenCondition = whenAttribute && !element.conditionalInclusion.call(element, 'when');
     var mediaCondition = !element.conditionalInclusion.call(element, 'media');
 
     return getConditionalUrl(element, whenCondition, mediaCondition, element.altSrcInclude);

--- a/h-include.js
+++ b/h-include.js
@@ -108,7 +108,7 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   var getUrl = function(element) {
     var whenAttribute = element.getAttribute('when');
     var whenFalseUrl = element.getAttribute('when-false-src');
-    var whenCondition = whenAttribute && !element.conditionalInclusion.call(element, 'when');
+    var whenCondition = whenAttribute && whenFalseUrl && !element.conditionalInclusion.call(element, 'when');
     var mediaCondition = !element.conditionalInclusion.call(element, 'media');
 
     return getConditionalUrl(element, whenCondition, mediaCondition, element.altSrcInclude);

--- a/h-include.js
+++ b/h-include.js
@@ -106,8 +106,9 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   };
 
   var getUrl = function(element) {
+    var whenAttribute = element.getAttribute('when');
     var whenFalseUrl = element.getAttribute('when-false-src');
-    var whenCondition = whenFalseUrl && !element.conditionalInclusion.call(element, 'when');
+    var whenCondition = whenAttribute && !element.conditionalInclusion.call(element, 'when');
     var mediaCondition = !element.conditionalInclusion.call(element, 'media');
 
     return getConditionalUrl(element, whenCondition, mediaCondition, element.altSrcInclude);

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -103,8 +103,9 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   };
 
   var getUrl = function(element) {
+    var whenAttribute = element.getAttribute('when');
     var whenFalseUrl = element.getAttribute('when-false-src');
-    var whenCondition = whenFalseUrl && !element.conditionalInclusion.call(element, 'when');
+    var whenCondition = whenAttribute && !element.conditionalInclusion.call(element, 'when');
     var mediaCondition = !element.conditionalInclusion.call(element, 'media');
 
     return getConditionalUrl(element, whenCondition, mediaCondition, element.altSrcInclude);

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -105,7 +105,7 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   var getUrl = function(element) {
     var whenAttribute = element.getAttribute('when');
     var whenFalseUrl = element.getAttribute('when-false-src');
-    var whenCondition = whenAttribute && !element.conditionalInclusion.call(element, 'when');
+    var whenCondition = whenAttribute && whenFalseUrl && !element.conditionalInclusion.call(element, 'when');
     var mediaCondition = !element.conditionalInclusion.call(element, 'media');
 
     return getConditionalUrl(element, whenCondition, mediaCondition, element.altSrcInclude);

--- a/lib/h-include.js
+++ b/lib/h-include.js
@@ -105,7 +105,7 @@ window.HInclude.HIncludeElement = window.HIncludeElement = (function() {
   var getUrl = function(element) {
     var whenAttribute = element.getAttribute('when');
     var whenFalseUrl = element.getAttribute('when-false-src');
-    var whenCondition = whenAttribute && whenFalseUrl && !element.conditionalInclusion.call(element, 'when');
+    var whenCondition = whenAttribute && !element.conditionalInclusion.call(element, 'when');
     var mediaCondition = !element.conditionalInclusion.call(element, 'media');
 
     return getConditionalUrl(element, whenCondition, mediaCondition, element.altSrcInclude);

--- a/static/alt/when-fail-no-when-false-src-alt-pass.html
+++ b/static/alt/when-fail-no-when-false-src-alt-pass.html
@@ -36,9 +36,8 @@
 <script type="text/javascript">
 setTimeout(function(){
   const a = document.getElementById('alt-included');
-  const aText = a.innerHTML;
 
-  expect(aText === 'alt - this text is included');
+  expect(!a);
 }, 1000);
 </script>
   </body>


### PR DESCRIPTION
Fixes #112

Previously, the `when` predicate was only evaluated if `when-false-src` attribute was present, due to this logic:

  var whenCondition = whenFalseUrl && !element.conditionalInclusion.call(...)

This prevented using `when` alone for conditional inclusion (showing content when predicate is true, nothing otherwise).

Changes:
- Changed condition to check for `when` attribute existence instead
- When predicate fails with no `when-false-src`, no HTTP request is made
- Updated test expectations to reflect corrected behavior
- `alt` attribute is only used for HTTP errors, not conditional logic

The fix maintains proper separation of concerns:
- Conditionals (`when`, `media`) gate whether to make a request
- `alt` only handles HTTP request failures